### PR TITLE
Add provide-mod for declaratively modifying entities

### DIFF
--- a/src/engine/main/wish_engine/api/mods.cljc
+++ b/src/engine/main/wish_engine/api/mods.cljc
@@ -1,0 +1,40 @@
+(ns wish-engine.api.mods)
+
+(defn apply-mod-to-entity [entity mod-fn]
+  (when-not (meta mod-fn)
+    (throw (ex-info "Invalid mod-fn (no meta)"
+                    {:fn mod-fn
+                     :apply-to entity})))
+
+  (let [{:keys [mod-id]} (meta mod-fn)
+        existing-meta (meta entity)
+        applied? (mod-id (:mods existing-meta))]
+    (if applied?
+      entity
+      (with-meta
+        (mod-fn entity)
+        (update existing-meta :mods (fnil conj #{}) mod-id)))))
+
+(defn apply-mods-to-entity [entity mods-coll]
+  (reduce
+    apply-mod-to-entity
+    entity
+    mods-coll))
+
+(defn install-mod-on-type [entities-map entity-id mod-fn]
+  (if (entity-id entities-map)
+    (update entities-map entity-id apply-mod-to-entity mod-fn)
+    entities-map))
+
+(defn install [state entity-id mod-fn]
+  (->> (keys state)
+       (remove #{:mods})
+
+       (reduce
+         (fn [s entity-kind]
+           (update s entity-kind install-mod-on-type entity-id mod-fn))
+         state)))
+
+(defn with-mods [state entity]
+  (let [mods (vals (get-in state [:mods (:id entity)]))]
+    (apply-mods-to-entity entity mods)))

--- a/src/engine/main/wish_engine/runtime_eval.cljs
+++ b/src/engine/main/wish_engine/runtime_eval.cljs
@@ -99,6 +99,7 @@
 (export-fn vec)
 
 (export-fn assoc)
+(export-fn update)
 (export-fn keys)
 (export-fn vals)
 

--- a/src/engine/main/wish_engine/scripting_api.cljc
+++ b/src/engine/main/wish_engine/scripting_api.cljc
@@ -77,7 +77,8 @@
             [wish-engine.api.attr :as attr]
             [wish-engine.api.features :as features]
             [wish-engine.api.limited-use :as limited-use]
-            [wish-engine.api.list :as list]))
+            [wish-engine.api.list :as list]
+            [wish-engine.api.mods :as mods]))
 
 
 (def ^:no-doc exported-fns {})
@@ -276,7 +277,8 @@
           assoc (:id spec)
           (->> spec
                limited-use/validate-spec
-               limited-use/compile-spec)))
+               limited-use/compile-spec
+               (mods/with-mods state))))
 
 (defn-api add-limited-use
   "Legacy alias for `provide-limited-use`"
@@ -411,3 +413,17 @@
   (when-not *engine-state*
     (throw-msg "declare-list must be called at the top level. Try `add-to-list`"))
   (swap! *engine-state* add-to-list* "declare-list" id-or-spec entries))
+
+
+; ======= Feature augmentation ============================
+
+(defn-api provide-mod
+  "Provide a modification to an entity."
+  [state mod-id entity-id f]
+  (when *engine-state*
+    (throw-msg "provide-mod must not be called at the top level."))
+
+  (let [mod-fn (vary-meta f assoc :mod-id mod-id)]
+    (-> state
+        (assoc-in [:mods entity-id mod-id] mod-fn)
+        (mods/install entity-id mod-fn))))

--- a/src/engine/main/wish_engine/scripting_api.cljc
+++ b/src/engine/main/wish_engine/scripting_api.cljc
@@ -432,7 +432,7 @@
      (declare-feature
        {:id :fuel-upgrade
         :! (on-state
-             (provide-simple-mod
+             (provide-mod
                :fuel-upgrade#mod
                :fuel#uses
                :restore-amount
@@ -469,7 +469,7 @@
      (declare-feature
        {:id :fuel-upgrade
         :! (on-state
-             (provide-simple-mod
+             (provide-scalar-mod
                :fuel-upgrade#mod
                :fuel#uses
                :restore-amount + 2))})

--- a/src/engine/main/wish_engine/spec/class.cljc
+++ b/src/engine/main/wish_engine/spec/class.cljc
@@ -1,0 +1,23 @@
+(ns wish-engine.spec.class
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::id keyword?)
+(s/def ::identified (s/keys :req-un [::id]))
+
+(s/def ::name string?)
+(s/def ::named (s/keys :req-un [::named]))
+
+(s/def ::! ifn?)
+(s/def ::state-modifier (s/keys :req-un [::!]))
+(s/def ::state-modifiable (s/keys :opt-un [::!]))
+
+(s/def ::base-entity (s/and ::identified
+                            ::named
+                            ::state-modifiable))
+
+(s/def ::levels (s/map-of number? ::state-modifier))
+(s/def ::levelable (s/keys :opt-un [::levels]))
+
+(s/def ::obj (s/and ::base-entity
+                    ::levelable))
+

--- a/src/engine/test/wish_engine/scripting_api_test.cljs
+++ b/src/engine/test/wish_engine/scripting_api_test.cljs
@@ -598,4 +598,55 @@
             limited-use (get-in s [:limited-uses :fuel#uses])]
         (is (ifn? (:restore-amount limited-use)))
         (is (= 4 ((:restore-amount limited-use) {:used 42}))))))
-  )
+
+  (testing "(update) syntax"
+    (let [{{f :serenity f' :fuel-upgrade}
+           :features}
+          (eval-state
+            '(declare-features
+               {:id :fuel-upgrade
+                :! (on-state
+                     (provide-mod
+                       :fuel-upgrade#mod
+                       :fuel#uses
+                       :restore-amount
+                       (fn [original-fn]
+                         (fn [arg]
+                           (+ (original-fn arg) 2)))))}
+
+               {:id :serenity
+                :! (on-state
+                     (provide-limited-use
+                       {:id :fuel#uses
+                        :name "Fuel"
+                        :restore-amount 2}))}))
+          state! (comp (:! f') (:! f))
+          s (state! {})
+          limited-use (get-in s [:limited-uses :fuel#uses])]
+      (is (ifn? (:restore-amount limited-use)))
+      (is (= 4 ((:restore-amount limited-use) {:used 42}))))))
+
+(deftest provide-scalar-mod-test
+  (testing "Scalar mod for fn value"
+    (let [{{f :serenity f' :fuel-upgrade}
+           :features}
+          (eval-state
+            '(declare-features
+               {:id :fuel-upgrade
+                :! (on-state
+                     (provide-scalar-mod
+                       :fuel-upgrade#mod
+                       :fuel#uses
+                       :restore-amount + 2))}
+
+               {:id :serenity
+                :! (on-state
+                     (provide-limited-use
+                       {:id :fuel#uses
+                        :name "Fuel"
+                        :restore-amount 2}))}))
+          state! (comp (:! f') (:! f))
+          s (state! {})
+          limited-use (get-in s [:limited-uses :fuel#uses])]
+      (is (ifn? (:restore-amount limited-use)))
+      (is (= 4 ((:restore-amount limited-use) {:used 42}))))))


### PR DESCRIPTION
The example we have in the scripting-api-test is augmenting the
:restore-amount function of a limited use. This could be used by a D&D
feat, for example, to increase how much of a resource is available to a
player, or to provide feature description clarifications.
